### PR TITLE
feat: support publish_hubble_image to dockerhub automatically (V2)

### DIFF
--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -19,16 +19,16 @@ jobs:
       
     steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Checkout latest
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.BRANCH }}
@@ -50,7 +50,7 @@ jobs:
         # see https://github.com/actions/runner/issues/662 for more details
 
     - name: Build X86 & ARM And Push All
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       if: ${{ env.NEED_UPDATE == 'true' }}
       with:
         context: .

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -1,0 +1,72 @@
+name: "Publish hubble image(latest)"
+
+on:
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  build_latest:
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY_URL: apache/hugegraph-toolchain
+      BRANCH: master
+      IMAGE_URL: hugegraph/hubble:latest
+      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      OWNER: hugegraph
+      REPO: actions
+      LAST_HUBBLE_HASH: ${{vars.LAST_HUBBLE_HASH}}
+      
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Checkout latest
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ env.REPOSITORY_URL }}
+        ref: ${{ env.BRANCH }}
+        fetch-depth: 2
+
+    - name: Get current commit-hash
+      run: |
+        current_commit_hash=$(git rev-parse HEAD)
+        echo "CURRENT_COMMIT_HASH=$current_commit_hash" >> $GITHUB_ENV
+
+    - name: Check if an update is needed
+      run: |
+        need_update='false'
+        if [[ "$CURRENT_COMMIT_HASH" != "$LAST_HUBBLE_HASH" ]]; then
+          need_update='true'
+        fi
+        echo "NEED_UPDATE=$need_update" >> $GITHUB_ENV
+        # TODO: replace `if` statements for exit if github provide support for exit gracefully,
+        # see https://github.com/actions/runner/issues/662 for more details
+
+    - name: Build X86 & ARM And Push All
+      uses: docker/build-push-action@v4
+      if: ${{ env.NEED_UPDATE == 'true' }}
+      with:
+        context: .
+        file: ./hugegraph-hubble/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ env.IMAGE_URL }}
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Updata last commit-hash
+      if: ${{ env.NEED_UPDATE == 'true' }}
+      run: |
+        curl -L -X PATCH \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        https://api.github.com/repos/$OWNER/$REPO/actions/variables/LAST_HUBBLE_HASH \
+        -d '{"name":"LAST_HUBBLE_HASH","value":"'"$CURRENT_COMMIT_HASH"'"}'

--- a/.github/workflows/publish_latest_server_image.yml
+++ b/.github/workflows/publish_latest_server_image.yml
@@ -19,16 +19,16 @@ jobs:
       
     steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Checkout latest
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.BRANCH }}
@@ -51,7 +51,7 @@ jobs:
 
     - name: Build X86 Image
       if: ${{ env.NEED_UPDATE == 'true' }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         load: true
@@ -73,7 +73,7 @@ jobs:
 
     - name: Build ARM & Push all
       if: ${{ env.NEED_UPDATE == 'true' }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -1,0 +1,48 @@
+name: "Publish hubble image(release)"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        default: ''
+        description: 'The branch name should be like *-x.x.x, for example release-1.0.0'
+
+jobs:
+  build_latest:
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY_URL: apache/hugegraph-toolchain
+      BRANCH: ${{inputs.branch}}
+
+    steps:
+    - name: Set image_url
+      run: |
+        image_url=hugegraph/hubble:$(echo "${{ inputs.branch }}" | grep -oP '(\d+\.\d+\.\d+)')
+        echo $image_url && echo "IMAGE_URL=$image_url" >> $GITHUB_ENV
+        
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Checkout latest
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ env.REPOSITORY_URL }}
+        ref: ${{ env.BRANCH }}
+        fetch-depth: 2
+
+    - name: Build X86 &ARM And Push All
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./hugegraph-hubble/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ env.IMAGE_URL }}
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -21,23 +21,23 @@ jobs:
         echo $image_url && echo "IMAGE_URL=$image_url" >> $GITHUB_ENV
         
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Checkout latest
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.BRANCH }}
         fetch-depth: 2
 
     - name: Build X86 &ARM And Push All
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: ./hugegraph-hubble/Dockerfile

--- a/.github/workflows/publish_release_server_image.yml
+++ b/.github/workflows/publish_release_server_image.yml
@@ -21,23 +21,23 @@ jobs:
         echo $image_url && echo "image_url=$image_url" >> $GITHUB_ENV
         
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Checkout latest
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.BRANCH }}
         fetch-depth: 2
 
     - name: Build X86 Image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         load: true
@@ -58,7 +58,7 @@ jobs:
         docker ps -a
 
     - name: Build ARM & Push all
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: ./Dockerfile


### PR DESCRIPTION
## Main change
Logic is the same as the pr to publish server image: [publish_server_image](https://github.com/hugegraph/actions/pull/1), which can avoid publish images repeatedly.
## Before Merge
Before merge, admin should set the public var `LAST_HUBBLE_HASH` as an empty value or test value.
![image](https://github.com/hugegraph/actions/assets/49650772/378d9f98-1340-41a6-a199-29c55a4e9add)
