### PR TITLE
feat: add the mvn args for docker build, like: -P stage

### DIFF
--- a/.github/workflows/publish_computer_image.yml
+++ b/.github/workflows/publish_computer_image.yml
@@ -19,16 +19,28 @@ on:
         default: 'hugegraph/hugegraph-computer-operator:latest'
       manager_image_url:
         required: true
-        default: 'hugegraph/hugegraph-computer-operator-manager:latest'  
+        default: 'hugegraph/hugegraph-computer-operator-manager:latest'
+      # TODO: avoid to use the fixed version
+      version:
+        required: true
+        default: '1.2.0'
+        description: 'the current release version'
       docker_registry_url:
         required: false
         default: ''
+      maven_args:
+        required: false
+        default: ''
+        description: 'mvn build args, like "-P stage"'
+
 env:
   repository_url: apache/hugegraph-computer
   repository_branch: master
   computer_image_url: hugegraph/hugegraph-computer:latest
   operator_image_url: hugegraph/hugegraph-computer-operator:latest
-  docker_registry_url: ""
+  version: 1.2.0
+  docker_registry_url: ''
+  maven_args: ''
 
 jobs:
   build:
@@ -43,7 +55,9 @@ jobs:
          echo "operator_image_url=${{ github.event.inputs.operator_image_url }}" >> $GITHUB_ENV
          echo "manager_image_url=${{ github.event.inputs.manager_image_url }}" >> $GITHUB_ENV         
          echo "docker_registry_url=${{ github.event.inputs.docker_registry_url }}" >> $GITHUB_ENV
-          
+         echo "maven_args=${{ github.event.inputs.maven_args }}" >> $GITHUB_ENV
+         echo "version=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         
@@ -81,7 +95,7 @@ jobs:
       
       - name: Package
         run: |
-          mvn clean package -DskipTests
+          mvn clean package ${{ env.maven_args }} -DskipTests
 
       - name: Build CRD
         run: |
@@ -92,7 +106,7 @@ jobs:
       - name: Build Computer Image
         uses: docker/build-push-action@v5
         with:
-          context: ./apache-hugegraph-computer-incubating-1.0.0
+          context: ./apache-hugegraph-computer-incubating-${{ env.version }}
           file: ./computer-dist/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.computer_image_url }}

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -4,7 +4,11 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
-
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
+      
 jobs:
   build_latest:
     runs-on: ubuntu-latest
@@ -16,6 +20,7 @@ jobs:
       OWNER: hugegraph
       REPO: actions
       LAST_HUBBLE_HASH: ${{vars.LAST_HUBBLE_HASH}}
+      MVN_ARGS: ${{inputs.mvn_args}}
       
     steps:
     - name: Set up Docker Buildx
@@ -60,6 +65,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
 
     - name: Updata last commit-hash
       if: ${{ env.NEED_UPDATE == 'true' }}

--- a/.github/workflows/publish_latest_loader_image.yml
+++ b/.github/workflows/publish_latest_loader_image.yml
@@ -4,7 +4,11 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
-
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
+      
 jobs:
   build_latest:
     runs-on: ubuntu-latest
@@ -16,7 +20,8 @@ jobs:
       OWNER: hugegraph
       REPO: actions
       LAST_LOADER_HASH: ${{vars.LAST_LOADER_HASH}}
-      
+      MVN_ARGS: ${{inputs.mvn_args}}
+
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -60,6 +65,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
 
     - name: Updata last commit-hash
       if: ${{ env.NEED_UPDATE == 'true' }}

--- a/.github/workflows/publish_latest_server_image.yml
+++ b/.github/workflows/publish_latest_server_image.yml
@@ -4,7 +4,11 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
-
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
+      
 jobs:
   build_latest:
     runs-on: ubuntu-latest
@@ -16,7 +20,8 @@ jobs:
       OWNER: hugegraph
       REPO: actions
       LAST_SERVER_HASH: ${{vars.LAST_SERVER_HASH}}
-      
+      MVN_ARGS: ${{inputs.mvn_args}}
+
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -59,6 +64,7 @@ jobs:
         tags: ${{ env.IMAGE_URL }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
 
     - name: Test X86 Image
       if: ${{ env.NEED_UPDATE == 'true' }}
@@ -83,6 +89,7 @@ jobs:
         tags: ${{ env.IMAGE_URL }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
 
     - name: Updata last commit-hash
       if: ${{ env.NEED_UPDATE == 'true' }}

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -6,6 +6,10 @@ on:
         required: true
         default: ''
         description: 'The branch name should be like *-x.x.x, for example release-1.0.0'
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
 
 jobs:
   build_latest:
@@ -13,6 +17,7 @@ jobs:
     env:
       REPOSITORY_URL: apache/hugegraph-toolchain
       BRANCH: ${{inputs.branch}}
+      MVN_ARGS: ${{inputs.mvn_args}}
 
     steps:
     - name: Set image_url
@@ -46,3 +51,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}

--- a/.github/workflows/publish_release_loader_image.yml
+++ b/.github/workflows/publish_release_loader_image.yml
@@ -6,6 +6,10 @@ on:
         required: true
         default: ''
         description: 'The branch name should be like *-x.x.x, for example release-1.0.0'
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
 
 jobs:
   build_latest:
@@ -13,6 +17,7 @@ jobs:
     env:
       REPOSITORY_URL: apache/hugegraph-toolchain
       BRANCH: ${{inputs.branch}}
+      MVN_ARGS: ${{inputs.mvn_args}}
 
     steps:
     - name: Set image_url
@@ -46,3 +51,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}

--- a/.github/workflows/publish_release_server_image.yml
+++ b/.github/workflows/publish_release_server_image.yml
@@ -6,6 +6,10 @@ on:
         required: true
         default: ''
         description: 'The branch name should be like *-x.x.x, for example release-1.0.0'
+    mvn_args:
+      required: false
+      default: ''
+      description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
 
 jobs:
   build_latest:
@@ -13,6 +17,7 @@ jobs:
     env:
       REPOSITORY_URL: apache/hugegraph
       BRANCH: ${{inputs.branch}}
+      MVN_ARGS: ${{inputs.mvn_args}}
 
     steps:
     - name: Set image_url
@@ -67,3 +72,4 @@ jobs:
         tags: ${{ env.image_url }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}


### PR DESCRIPTION
# Main change 
In release/latest, I add the build-args for the `build and push` action, which can be use in the related dockerfile `server/loader/hubble`
In computer, I directly add the mvn args.
And I have built the `server/loader/hubble/computer` in my own repo: https://github.com/aroundabout/action_demo/actions
[build computer action](https://github.com/aroundabout/action_demo/actions/runs/7190817797)
[build server action](https://github.com/aroundabout/action_demo/actions/runs/7190572417/job/19583913321)
[build hubble action](https://github.com/aroundabout/action_demo/actions/runs/7190514665/job/19583762315)
[build loader action](https://github.com/aroundabout/action_demo/actions/runs/7190567660/job/19583902666)

And I have tested `server/loader/hubble`.
The computer related images are not tested.

![image](https://github.com/hugegraph/actions/assets/49650772/fceff5a7-43bc-4435-bbb8-262f002388a2)

# related PR for docker file
server:  https://github.com/apache/incubator-hugegraph/pull/2386
hubble/loader:  https://github.com/apache/incubator-hugegraph-toolchain/pull/556

