### PR TITLE
feat: support pd-store-server image publishment

### DIFF
--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPOSITORY_URL: apache/hugegraph
-      BRANCH: pd-store-docker
+      BRANCH: master
       PD_IMAGE_URL: hugegraph/pd:latest
       STORE_IMAGE_URL: hugegraph/store:latest
       SERVER_IMAGE_URL: hugegraph/server:latest

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       REPOSITORY_URL: apache/hugegraph
       BRANCH: pd-store-docker
+      HG_BUILD_IMAGE_URL: hugegraph/hugegraph.build:latest
       PD_IMAGE_URL: hugegraph/pd:latest
       STORE_IMAGE_URL: hugegraph/store:latest
       SERVER_IMAGE_URL: hugegraph/server:latest
@@ -39,8 +40,15 @@ jobs:
         fetch-depth: 2
 
     - name: Build HugeGraph
-      run: |
-        docker build -f Dockerfile.build -t hugegraph/hugegraph.build .
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.build
+        load: true
+        tags: ${{ env.HG_BUILD_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 PD Image
       uses: docker/build-push-action@v5

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -38,11 +38,11 @@ jobs:
         ref: ${{ env.BRANCH }}
         fetch-depth: 2
 
-    - name: Build Hugegraph
+    - name: Build HugeGraph
       run: |
         docker build -f Dockerfile.build -t hugegraph/hugegraph.build .
 
-    - name: Build X86 PD Image
+    - name: Build x86 PD Image
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -53,7 +53,7 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
-    - name: Build X86 Store Image
+    - name: Build x86 Store Image
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -64,7 +64,7 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
-    - name: Build X86 Server Image
+    - name: Build x86 Server Image
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -75,7 +75,7 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
-    - name: Test X86 Images
+    - name: Test x86 Images
       run: |
         docker images
         docker run -itd --name=pd --network host $PD_IMAGE_URL
@@ -90,7 +90,7 @@ jobs:
         curl 0.0.0.0:8080 || exit
         docker ps -a
 
-    - name: Push X86 & ARM PD Images
+    - name: Push x86 & ARM PD Images
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -102,7 +102,7 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
-    - name: Push X86 & ARM Store Images
+    - name: Push x86 & ARM Store Images
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -114,7 +114,7 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
-    - name: Push X86 & ARM Server Images
+    - name: Push x86 & ARM Server Images
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -1,0 +1,129 @@
+name: "Publish pd-store-server image(latest)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mvn_args:
+        required: false
+        default: 'MAVEN_ARGS=-P stage'
+        description: 'mvn build args, like "MAVEN_ARGS=-P stage"'
+ 
+jobs:
+  build_latest:
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY_URL: apache/hugegraph
+      BRANCH: pd-store-docker
+      PD_IMAGE_URL: hugegraph/pd:latest
+      STORE_IMAGE_URL: hugegraph/store:latest
+      SERVER_IMAGE_URL: hugegraph/server:latest
+      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      OWNER: hugegraph
+      REPO: actions
+      LAST_SERVER_HASH: ${{vars.LAST_SERVER_HASH}}
+      MVN_ARGS: ${{inputs.mvn_args}}
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Checkout latest
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ env.REPOSITORY_URL }}
+        ref: ${{ env.BRANCH }}
+        fetch-depth: 2
+
+    - name: Build Hugegraph
+      run: |
+        docker build -f Dockerfile.build -t hugegraph/hugegraph.build .
+
+    - name: Build X86 PD Image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-pd/Dockerfile
+        load: true
+        tags: ${{ env.PD_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
+
+    - name: Build X86 Store Image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-store/Dockerfile
+        load: true
+        tags: ${{ env.STORE_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
+
+    - name: Build X86 Server Image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-server/Dockerfile
+        load: true
+        tags: ${{ env.SERVER_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
+
+    - name: Test X86 Images
+      run: |
+        docker images
+        docker run -itd --name=pd --network host $PD_IMAGE_URL
+        sleep 10s
+        docker run -itd --name=store --network host $STORE_IMAGE_URL
+        sleep 10s
+        docker run -itd --name=server --network host $SERVER_IMAGE_URL
+        sleep 10s
+        curl 0.0.0.0:8080 || exit
+        docker ps -a
+        sleep 10s
+        curl 0.0.0.0:8080 || exit
+        docker ps -a
+
+    - name: Push X86 & ARM PD Images
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-pd/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.PD_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
+
+    - name: Push X86 & ARM Store Images
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-store/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.STORE_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}
+
+    - name: Push X86 & ARM Server Images
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./hugegraph-server/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.SERVER_IMAGE_URL }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: ${{ env.MVN_ARGS }}

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -50,6 +50,10 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: ${{ env.MVN_ARGS }}
 
+    - name: Test
+      run: |
+        docker images
+
     - name: Build x86 PD Image
       uses: docker/build-push-action@v5
       with:

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -17,10 +17,8 @@ jobs:
       PD_IMAGE_URL: hugegraph/pd:latest
       STORE_IMAGE_URL: hugegraph/store:latest
       SERVER_IMAGE_URL: hugegraph/server:latest
-      GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       OWNER: hugegraph
       REPO: actions
-      LAST_SERVER_HASH: ${{vars.LAST_SERVER_HASH}}
       MVN_ARGS: ${{inputs.mvn_args}}
 
     steps:

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -74,12 +74,11 @@ jobs:
         docker images
         docker run -itd --name=pd --network host $PD_IMAGE_URL
         sleep 10s
+        curl 0.0.0.0:8620 || exit
         docker run -itd --name=store --network host $STORE_IMAGE_URL
         sleep 10s
+        curl 0.0.0.0:8520 || exit
         docker run -itd --name=server --network host $SERVER_IMAGE_URL
-        sleep 10s
-        curl 0.0.0.0:8080 || exit
-        docker ps -a
         sleep 10s
         curl 0.0.0.0:8080 || exit
         docker ps -a

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -14,12 +14,9 @@ jobs:
     env:
       REPOSITORY_URL: apache/hugegraph
       BRANCH: pd-store-docker
-      HG_BUILD_IMAGE_URL: hugegraph/hugegraph.build:latest
       PD_IMAGE_URL: hugegraph/pd:latest
       STORE_IMAGE_URL: hugegraph/store:latest
       SERVER_IMAGE_URL: hugegraph/server:latest
-      OWNER: hugegraph
-      REPO: actions
       MVN_ARGS: ${{inputs.mvn_args}}
 
     steps:
@@ -38,21 +35,6 @@ jobs:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.BRANCH }}
         fetch-depth: 2
-
-    - name: Build HugeGraph
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ./Dockerfile.build
-        load: true
-        tags: ${{ env.HG_BUILD_IMAGE_URL }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: ${{ env.MVN_ARGS }}
-
-    - name: Test
-      run: |
-        docker images
 
     - name: Build x86 PD Image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
As title, [publish_release_server_image.yml](https://github.com/hugegraph/actions/blob/master/.github/workflows/publish_release_server_image.yml) could be removed?