### PR TITLE
docs: add AGENTS.md and expand README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Purpose
+
+This repository contains shared GitHub Actions workflows for HugeGraph projects.
+Its main purpose is to publish Docker images, validate releases, and host small automation workflows used across HugeGraph repositories.
+
+## Repository Model
+
+- `latest` publishing is the automated path: scheduled or manually triggered, with hash gating to skip unchanged sources.
+- `release` publishing is the manual path: it publishes from a versioned branch and should run even if the source is unchanged.
+- Shared image publishing logic lives in [`.github/workflows/_publish_image_reusable.yml`](./.github/workflows/_publish_image_reusable.yml).
+- Thin `publish_latest_*.yml` and `publish_release_*.yml` files are wrappers that define trigger policy and per-image inputs.
+
+## Editing Rules
+
+- Prefer changing the reusable workflow first when the build or publish behavior is shared.
+- Keep wrapper workflows thin and explicit.
+- Do not merge `latest` and `release` wrappers unless the trigger semantics are truly identical.
+- Keep special-case workflows separate when they need extra prechecks, custom ordering, or non-standard release flow.
+
+## Important Files
+
+- [`README.md`](./README.md): human-facing overview of the workflow design.
+- [`.github/workflows/_publish_image_reusable.yml`](./.github/workflows/_publish_image_reusable.yml): shared publish implementation.
+- [`.github/workflows/publish_latest_*.yml`](./.github/workflows): automated publish wrappers.
+- [`.github/workflows/publish_release_*.yml`](./.github/workflows): manual release publish wrappers.
+
+## Before Making Changes
+
+- Read the relevant workflow and the reusable workflow together.
+- Preserve existing trigger semantics unless the task explicitly asks for a behavioral change.
+- Check whether the workflow is a standard publisher or a legacy / special-case flow before refactoring.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,138 @@
-# Hugegraph-Actions
+# HugeGraph Actions
 
-HugeGraph CI/Test Space
+HugeGraph Actions is the shared CI/CD workspace for HugeGraph repositories.
+It mainly hosts GitHub Actions workflows for publishing Docker images, validating releases, and coordinating repository-specific automation.
+
+## Core Design
+
+The image publishing workflows are intentionally split into two layers:
+
+```text
+                     Trigger
+                        |
+        +---------------+----------------+
+        |                                |
+   scheduled / manual                manual release
+   latest publish                    publish from branch
+        |                                |
+        v                                v
+  publish_latest_*.yml            publish_release_*.yml
+        \                                /
+         \                              /
+          +------------+---------------+
+                       |
+                       v
+      .github/workflows/_publish_image_reusable.yml
+                       |
+     +-----------------+-------------------+
+     |                                     |
+     v                                     v
+ resolve mode / branch / tag         build matrix per module
+     |                                     |
+     v                                     v
+ optional hash gate                  optional smoke test
+     |                                     |
+     +-----------------+-------------------+
+                       |
+                       v
+                 docker build/push
+```
+
+The two publishing modes behave differently:
+
+- `latest` mode
+  - scheduled or ad-hoc publish for the current main branch line
+  - skips work when the source hash has not changed
+  - updates the stored `LAST_*_HASH` variable after a successful publish
+
+- `release` mode
+  - manual publish from a versioned branch such as `release-1.7.0`
+  - always publishes when invoked
+  - derives the image tag from the release branch version
+
+## Why The Wrappers Stay Split
+
+Although the `latest` and `release` wrappers look similar, they encode different release semantics.
+
+- `latest` is the automatic path.
+  - It is scheduled for daily publication and can also be triggered manually.
+  - It uses the hash gate to avoid republishing unchanged sources.
+  - It usually targets the main development branch for each repository.
+
+- `release` is the intentional publication path.
+  - It is triggered manually.
+  - It expects a release branch and publishes that branch as a versioned image.
+  - It should run even if the source is unchanged, because the operator is explicitly asking for a release publication.
+
+The common build logic already lives in [`.github/workflows/_publish_image_reusable.yml`](./.github/workflows/_publish_image_reusable.yml), so the thin wrapper files mainly exist to keep the trigger semantics obvious and safe.
+
+## Reusable Workflow Responsibilities
+
+[`_publish_image_reusable.yml`](./.github/workflows/_publish_image_reusable.yml) is the real implementation layer.
+
+It handles:
+
+- resolving `latest` vs `release` mode
+- checking out the correct source commit
+- deriving the image tag
+- selecting per-module build settings from `build_matrix_json`
+- enabling QEMU and Buildx when needed
+- running optional smoke tests
+- pushing the final image
+- updating the latest-hash variable for `latest` mode only
+
+Wrapper workflows only provide the source repository, branch, matrix definition, and mode-specific inputs.
+
+## How To Extend
+
+When adding a new image publishing workflow, follow the same pattern:
+
+1. Create a thin `publish_latest_*.yml` wrapper if the image needs scheduled or hash-gated automatic publishing.
+2. Create a matching `publish_release_*.yml` wrapper if the image also needs manual release publishing.
+3. Put all shared build behavior into `_publish_image_reusable.yml` instead of duplicating Docker or checkout logic.
+4. Put image-specific values in the wrapper via `build_matrix_json`, especially:
+   - module name
+   - Dockerfile path
+   - build context
+   - image repository name
+   - platform list
+   - optional smoke test command
+
+Use the reusable workflow for behavior, and the wrapper for policy.
+
+### When To Keep A Special-Case Workflow Separate
+
+Keep a dedicated workflow file when the publishing flow has materially different behavior, for example:
+
+- integration prechecks before publishing
+- multiple images with custom dependency ordering
+- different trigger semantics that do not fit the `latest` / `release` split
+- legacy workflows that still require bespoke setup
+
+For example, [`.github/workflows/publish_latest_pd_store_server_image.yml`](./.github/workflows/publish_latest_pd_store_server_image.yml) has a more customized precheck-oriented flow than the standard image publishers.
+
+## Current Workflow Map
+
+- Standard reusable publish path:
+  - [`.github/workflows/publish_latest_loader_image.yml`](./.github/workflows/publish_latest_loader_image.yml)
+  - [`.github/workflows/publish_release_loader_image.yml`](./.github/workflows/publish_release_loader_image.yml)
+  - [`.github/workflows/publish_latest_server_image.yml`](./.github/workflows/publish_latest_server_image.yml)
+  - [`.github/workflows/publish_release_server_image.yml`](./.github/workflows/publish_release_server_image.yml)
+  - [`.github/workflows/publish_latest_hubble_image.yml`](./.github/workflows/publish_latest_hubble_image.yml)
+  - [`.github/workflows/publish_release_hubble_image.yml`](./.github/workflows/publish_release_hubble_image.yml)
+  - [`.github/workflows/publish_latest_vermeer_image.yml`](./.github/workflows/publish_latest_vermeer_image.yml)
+  - [`.github/workflows/publish_release_vermeer_image.yml`](./.github/workflows/publish_release_vermeer_image.yml)
+  - [`.github/workflows/publish_latest_ai_image.yml`](./.github/workflows/publish_latest_ai_image.yml)
+  - [`.github/workflows/publish_release_ai_image.yml`](./.github/workflows/publish_release_ai_image.yml)
+
+- Legacy or special-case workflows:
+  - [`.github/workflows/publish_hugegraph_hubble.yml`](./.github/workflows/publish_hugegraph_hubble.yml)
+  - [`.github/workflows/publish_computer_image.yml`](./.github/workflows/publish_computer_image.yml)
+  - [`.github/workflows/publish_latest_pd_store_server_image.yml`](./.github/workflows/publish_latest_pd_store_server_image.yml)
+
+## Practical Notes
+
+- `latest` workflows typically run on a schedule and accept manual dispatch.
+- `release` workflows typically accept only manual dispatch with a branch input.
+- Most image workflows inherit credentials and settings through the reusable workflow.
+- If you change the shared publishing behavior, update `_publish_image_reusable.yml` first and then adjust wrappers only where their inputs change.


### PR DESCRIPTION
Add a new AGENTS.md documenting the repository purpose, publishing model (latest vs release), editing rules, important files, and guidance to follow before making changes. 

Expand README.md into a comprehensive overview (HugeGraph Actions) that explains the two-layer wrapper+reusable workflow design, differences between latest and release modes, responsibilities of the reusable workflow, how to extend/add new image publishers, a map of current workflows, and practical notes for contributors. 

These changes clarify publishing semantics and contributor guidance for shared GitHub Actions workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* **文档**
  * 新增 `AGENTS.md` 文件，详细说明 HugeGraph 项目的 GitHub Actions 工作流程约定和结构，包括 `latest` 与 `release` 发布路径的定义、可复用工作流设计和贡献者指南
  * 更新 README 文档，完善 CI/CD 共享工作区说明，详细描述 Docker 镜像双层发布设计、发布语义差异对比，并补充工作流扩展指南和当前工作流文件清单

<!-- end of auto-generated comment: release notes by coderabbit.ai -->