### PR TITLE
fix(workflows): unify HugeGraph toolchain's CI

### DIFF
--- a/.github/workflows/_toolchain_go_ci_reusable.yml
+++ b/.github/workflows/_toolchain_go_ci_reusable.yml
@@ -1,0 +1,74 @@
+name: "Toolchain Go CI (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: "Java version used for HugeGraph environment preparation"
+        required: true
+        type: string
+      go_version:
+        description: "Go version used for the Go client test step"
+        required: true
+        type: string
+      use_stage:
+        description: "Whether to replace Maven settings with staged repo settings"
+        required: false
+        default: false
+        type: boolean
+      settings_path:
+        description: "Path to Maven settings.xml in the caller repository"
+        required: true
+        type: string
+      prepare_command:
+        description: "Environment/service preparation command(s)"
+        required: true
+        type: string
+      test_command:
+        description: "Test command(s)"
+        required: true
+        type: string
+
+jobs:
+  go-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Java ${{ inputs.java_version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Use staged maven repo settings
+        if: ${{ inputs.use_stage }}
+        env:
+          SETTINGS_PATH: ${{ inputs.settings_path }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.m2"
+          if [ -f "$HOME/.m2/settings.xml" ]; then
+            cp "$HOME/.m2/settings.xml" /tmp/settings.xml
+          fi
+          cp -vf "$SETTINGS_PATH" "$HOME/.m2/settings.xml"
+
+      - name: Prepare env and service
+        run: |
+          set -euo pipefail
+          ${{ inputs.prepare_command }}
+
+      - name: Set up Go ${{ inputs.go_version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go_version }}
+          cache: true
+
+      - name: Run test
+        run: |
+          set -euo pipefail
+          ${{ inputs.test_command }}

--- a/.github/workflows/_toolchain_java_ci_reusable.yml
+++ b/.github/workflows/_toolchain_java_ci_reusable.yml
@@ -1,0 +1,102 @@
+name: "Toolchain Java CI (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: "Java version used for compile/test steps"
+        required: true
+        type: string
+      python_version:
+        description: "Optional Python version for modules that need it"
+        required: false
+        default: ''
+        type: string
+      use_stage:
+        description: "Whether to replace Maven settings with staged repo settings"
+        required: false
+        default: false
+        type: boolean
+      settings_path:
+        description: "Path to Maven settings.xml in the caller repository"
+        required: true
+        type: string
+      compile_command:
+        description: "Compile command(s) executed before environment preparation"
+        required: true
+        type: string
+      prepare_command:
+        description: "Environment/service preparation command(s)"
+        required: false
+        default: ''
+        type: string
+      test_command:
+        description: "Test command(s)"
+        required: true
+        type: string
+      codecov_file:
+        description: "Coverage file glob passed to Codecov; empty disables upload"
+        required: false
+        default: ''
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  java-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Java ${{ inputs.java_version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Set up Python ${{ inputs.python_version }}
+        if: ${{ inputs.python_version != '' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+          cache: 'pip'
+
+      - name: Use staged maven repo settings
+        if: ${{ inputs.use_stage }}
+        env:
+          SETTINGS_PATH: ${{ inputs.settings_path }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.m2"
+          if [ -f "$HOME/.m2/settings.xml" ]; then
+            cp "$HOME/.m2/settings.xml" /tmp/settings.xml
+          fi
+          cp -vf "$SETTINGS_PATH" "$HOME/.m2/settings.xml"
+
+      - name: Compile
+        run: |
+          set -euo pipefail
+          ${{ inputs.compile_command }}
+
+      - name: Prepare env and service
+        if: ${{ inputs.prepare_command != '' }}
+        run: |
+          set -euo pipefail
+          ${{ inputs.prepare_command }}
+
+      - name: Run test
+        run: |
+          set -euo pipefail
+          ${{ inputs.test_command }}
+
+      - name: Upload coverage to Codecov
+        if: ${{ inputs.codecov_file != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ inputs.codecov_file }}

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ standard single-image flow          pd/store/server specialized flow
 The two publishing modes behave differently:
 
 - `latest` mode
-  - scheduled or ad-hoc publish for the current default branch line (master in `apache/hugegraph`)
-  - skips work when the source hash has not changed
-  - updates the stored `LAST_*_HASH` variable after a successful publish
+    - scheduled or ad-hoc publish for the current default branch line (master in `apache/hugegraph`)
+    - skips work when the source hash has not changed
+    - updates the stored `LAST_*_HASH` variable after a successful publish
 
 - `release` mode
-  - manual publish from a versioned branch such as `release-1.7.0`
-  - always publishes when invoked
-  - derives the image tag from the release branch version
+    - manual publish from a versioned branch such as `release-1.7.0`
+    - always publishes when invoked
+    - derives the image tag from the release branch version
 
 ## Critical Path: PD/Store/Server
 
@@ -96,14 +96,14 @@ Execution note:
 Although the `latest` and `release` wrappers look similar, they encode different release semantics.
 
 - `latest` is the automatic path.
-  - It is scheduled for daily publication and can also be triggered manually.
-  - It uses the hash gate to avoid republishing unchanged sources.
-  - It usually targets the main development branch for each repository.
+    - It is scheduled for daily publication and can also be triggered manually.
+    - It uses the hash gate to avoid republishing unchanged sources.
+    - It usually targets the main development branch for each repository.
 
 - `release` is the intentional publication path.
-  - It is triggered manually.
-  - It expects a release branch and publishes that branch as a versioned image.
-  - It should run even if the source is unchanged, because the operator is explicitly asking for a release publication.
+    - It is triggered manually.
+    - It expects a release branch and publishes that branch as a versioned image.
+    - It should run even if the source is unchanged, because the operator is explicitly asking for a release publication.
 
 Most wrappers use [`.github/workflows/_publish_image_reusable.yml`](./.github/workflows/_publish_image_reusable.yml).
 
@@ -144,12 +144,12 @@ When adding a new image publishing workflow, follow the same pattern:
 2. Create a matching `publish_release_*.yml` wrapper if the image also needs manual release publishing.
 3. Put shared build behavior into the appropriate reusable workflow instead of duplicating Docker or checkout logic.
 4. Put image-specific values in the wrapper via `build_matrix_json`, especially:
-   - module name
-   - Dockerfile path
-   - build context
-   - image repository name
-   - platform list
-   - optional smoke test command
+    - module name
+    - Dockerfile path
+    - build context
+    - image repository name
+    - platform list
+    - optional smoke test command
 
 Use the reusable workflow for behavior, and the wrapper for policy.
 
@@ -167,22 +167,32 @@ For example, [`.github/workflows/publish_latest_pd_store_server_image.yml`](./.g
 ## Current Workflow Map
 
 - Standard reusable publish path:
-  - [`.github/workflows/publish_latest_loader_image.yml`](./.github/workflows/publish_latest_loader_image.yml)
-  - [`.github/workflows/publish_release_loader_image.yml`](./.github/workflows/publish_release_loader_image.yml)
-  - [`.github/workflows/publish_latest_hubble_image.yml`](./.github/workflows/publish_latest_hubble_image.yml)
-  - [`.github/workflows/publish_release_hubble_image.yml`](./.github/workflows/publish_release_hubble_image.yml)
-  - [`.github/workflows/publish_latest_vermeer_image.yml`](./.github/workflows/publish_latest_vermeer_image.yml)
-  - [`.github/workflows/publish_release_vermeer_image.yml`](./.github/workflows/publish_release_vermeer_image.yml)
-  - [`.github/workflows/publish_latest_ai_image.yml`](./.github/workflows/publish_latest_ai_image.yml)
-  - [`.github/workflows/publish_release_ai_image.yml`](./.github/workflows/publish_release_ai_image.yml)
+    - [`.github/workflows/publish_latest_loader_image.yml`](./.github/workflows/publish_latest_loader_image.yml)
+    - [`.github/workflows/publish_release_loader_image.yml`](./.github/workflows/publish_release_loader_image.yml)
+    - [`.github/workflows/publish_latest_hubble_image.yml`](./.github/workflows/publish_latest_hubble_image.yml)
+    - [`.github/workflows/publish_release_hubble_image.yml`](./.github/workflows/publish_release_hubble_image.yml)
+    - [`.github/workflows/publish_latest_vermeer_image.yml`](./.github/workflows/publish_latest_vermeer_image.yml)
+    - [`.github/workflows/publish_release_vermeer_image.yml`](./.github/workflows/publish_release_vermeer_image.yml)
+    - [`.github/workflows/publish_latest_ai_image.yml`](./.github/workflows/publish_latest_ai_image.yml)
+    - [`.github/workflows/publish_release_ai_image.yml`](./.github/workflows/publish_release_ai_image.yml)
 
 - Dedicated reusable publish path:
-  - [`.github/workflows/publish_latest_pd_store_server_image.yml`](./.github/workflows/publish_latest_pd_store_server_image.yml)
-  - [`.github/workflows/publish_release_pd_store_server_image.yml`](./.github/workflows/publish_release_pd_store_server_image.yml)
+    - [`.github/workflows/publish_latest_pd_store_server_image.yml`](./.github/workflows/publish_latest_pd_store_server_image.yml)
+    - [`.github/workflows/publish_release_pd_store_server_image.yml`](./.github/workflows/publish_release_pd_store_server_image.yml)
 
 - Other legacy or special-case workflows:
-  - [`.github/workflows/publish_hugegraph_hubble.yml`](./.github/workflows/publish_hugegraph_hubble.yml)
-  - [`.github/workflows/publish_computer_image.yml`](./.github/workflows/publish_computer_image.yml)
+    - [`.github/workflows/publish_hugegraph_hubble.yml`](./.github/workflows/publish_hugegraph_hubble.yml)
+    - [`.github/workflows/publish_computer_image.yml`](./.github/workflows/publish_computer_image.yml)
+
+## Toolchain CI Design
+
+`apache/hugegraph-toolchain` follows the same reusable-workflow-plus-wrapper pattern for repository CI.
+Thin wrappers stay in the toolchain repository so each module keeps its own trigger policy and path filters, while shared setup and execution logic lives in:
+
+- [`.github/workflows/_toolchain_java_ci_reusable.yml`](./.github/workflows/_toolchain_java_ci_reusable.yml)
+- [`.github/workflows/_toolchain_go_ci_reusable.yml`](./.github/workflows/_toolchain_go_ci_reusable.yml)
+
+This keeps module-specific compile and test commands close to the source repository, while centralizing Java/Go runner setup, staged Maven settings, and optional Codecov upload behavior in `hugegraph/actions`.
 
 ## Practical Notes
 


### PR DESCRIPTION
- Add `.github/workflows/_toolchain_java_ci_reusable.yml` for Java-based
  HugeGraph Toolchain modules:
  - `hugegraph-client`
  - `hugegraph-loader`
  - `hugegraph-hubble`
  - `hugegraph-tools`
  - `hugegraph-spark-connector`
- Add `.github/workflows/_toolchain_go_ci_reusable.yml` for
  `hugegraph-client-go`.
- Support optional Python setup for modules such as `hugegraph-hubble`.
- Support optional Codecov upload while keeping coverage configuration in the
  caller repository.
- Add a new `Toolchain CI Design` section to `README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增可复用的 Go CI 工作流，支持自定义 Java 和 Go 版本、Maven 设置及测试命令
  * 新增可复用的 Java CI 工作流，支持自定义 Java 和 Python 版本、构建和测试命令，以及 Codecov 集成

* **文档**
  * 更新工具链 CI 设计文档，说明新增工作流的用法和功能特性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->