### PR TITLE
chore(workflows): upgrade checkout to v6

### DIFF
--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -166,7 +166,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository_url }}
         ref: ${{ needs.prepare.outputs.checkout_ref }}

--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -164,7 +164,7 @@ jobs:
         fi
 
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -305,7 +305,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -401,7 +401,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}

--- a/.github/workflows/publish_computer_image.yml
+++ b/.github/workflows/publish_computer_image.yml
@@ -80,7 +80,7 @@ jobs:
           go-version: '1.19'
           
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.repository_url }}
           ref: ${{ env.repository_branch }}

--- a/.github/workflows/publish_hugegraph_hubble.yml
+++ b/.github/workflows/publish_hugegraph_hubble.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository_url }}
           ref: ${{ inputs.repository_branch }}

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -32,7 +32,7 @@ jobs:
       USE_STAGE: 'true' # Whether to include the stage repository.
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Summary
- Upgrade all workflow uses of actions/checkout from v3/v4 to v6.
- Address GitHub Actions Node.js 20 deprecation warnings for checkout.
- Keep workflow triggers, matrices, Docker build/publish logic, and release behavior unchanged.

## Validation
- rg --hidden -n "actions/checkout@v[0-9]+" .
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
- git diff --check

Note: actionlint is not installed in the local environment, so validation used YAML parsing plus diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级CI/CD工作流中的源代码检出操作版本，以确保构建和发布流程使用最新的工具版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->