### PR TITLE
perf(images): persist multi-platform build caches

### DIFF
--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -141,6 +141,7 @@ jobs:
         IMAGE_REPO_RELEASE: ${{ matrix.image_repo_release }}
         PLATFORMS_LATEST: ${{ matrix.platforms_latest }}
         PLATFORMS_RELEASE: ${{ matrix.platforms_release }}
+        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image }}
       run: |
         set -euo pipefail
 
@@ -159,11 +160,35 @@ jobs:
         image_url="${image_repo}:${VERSION_TAG}"
         cache_scope="${COMPONENT}-${MODULE}"
 
+        if [ -n "$REGISTRY_CACHE_IMAGE" ]; then
+          cache_from="type=registry,ref=${REGISTRY_CACHE_IMAGE}"
+          cache_to_min="type=registry,ref=${REGISTRY_CACHE_IMAGE},mode=min"
+          cache_to_max="type=registry,ref=${REGISTRY_CACHE_IMAGE},mode=max"
+          cache_backend="registry"
+        else
+          cache_from="type=gha,scope=${cache_scope}"
+          cache_to_min="type=gha,scope=${cache_scope},mode=min"
+          cache_to_max="type=gha,scope=${cache_scope},mode=max"
+          cache_backend="gha"
+        fi
+
         {
           echo "image_url=$image_url"
           echo "platforms=$platforms"
           echo "cache_scope=$cache_scope"
+          echo "cache_from=$cache_from"
+          echo "cache_to_min=$cache_to_min"
+          echo "cache_to_max=$cache_to_max"
+          echo "cache_backend=$cache_backend"
         } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Build parameters: ${MODULE}"
+          echo
+          echo "| Image | Platforms | Cache backend | Cache reference |"
+          echo "| --- | --- | --- | --- |"
+          echo "| \`${image_url}\` | \`${platforms}\` | \`${cache_backend}\` | \`${REGISTRY_CACHE_IMAGE:-$cache_scope}\` |"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Checkout source (${{ matrix.module }})
       uses: actions/checkout@v6
@@ -196,8 +221,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=min
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_min }}
         build-args: ${{ inputs.mvn_args }}
 
     - name: Build x86 image for smoke test (${{ matrix.module }})
@@ -209,8 +234,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=min
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_min }}
 
     - name: Run smoke test (${{ matrix.module }})
       if: ${{ matrix.smoke_test }}
@@ -239,8 +264,8 @@ jobs:
         platforms: ${{ steps.params.outputs.platforms }}
         push: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=max
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_max }}
         build-args: ${{ inputs.mvn_args }}
 
     - name: Build and push image (${{ matrix.module }})
@@ -252,8 +277,8 @@ jobs:
         platforms: ${{ steps.params.outputs.platforms }}
         push: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=max
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_max }}
 
   update_latest_hash:
     needs: [prepare, publish]

--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -141,7 +141,7 @@ jobs:
         IMAGE_REPO_RELEASE: ${{ matrix.image_repo_release }}
         PLATFORMS_LATEST: ${{ matrix.platforms_latest }}
         PLATFORMS_RELEASE: ${{ matrix.platforms_release }}
-        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image }}
+        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image || '' }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -191,7 +191,7 @@ jobs:
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ inputs.repository_url }}
         ref: ${{ needs.prepare.outputs.checkout_ref }}

--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -146,6 +146,23 @@ jobs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
+    - name: Summarize build cache strategy
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        {
+          echo "## PD / Store / Server image build"
+          echo
+          echo "- Cache backend: Docker Hub registry (BuildKit, mode=max)"
+          echo "- Cache channel: \`$MODE\`"
+          echo "- Cache writers: integration precheck and amd64 publish jobs"
+          echo "- Cache reader: arm64 publish jobs"
+          echo "- PD: \`hugegraph/pd:buildcache-$MODE\`"
+          echo "- Store: \`hugegraph/store:buildcache-$MODE\`"
+          echo "- Server (HStore): \`hugegraph/server:buildcache-$MODE\`"
+          echo "- Server (standalone): \`hugegraph/hugegraph:buildcache-$MODE\`"
+        } >> "$GITHUB_STEP_SUMMARY"
+
   integration_precheck:
     needs: prepare
     if: ${{ needs.prepare.outputs.need_update == 'true' && inputs.strict_mode }}
@@ -164,7 +181,7 @@ jobs:
         fi
 
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -194,8 +211,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/pd:precheck
-        cache-from: type=gha,scope=pd-store-server-pd-amd64
-        cache-to: type=gha,scope=pd-store-server-pd-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Store image for integration check
@@ -206,8 +223,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/store:precheck
-        cache-from: type=gha,scope=pd-store-server-store-amd64
-        cache-to: type=gha,scope=pd-store-server-store-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Server(hstore) image for integration check
@@ -218,8 +235,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/server:precheck
-        cache-from: type=gha,scope=pd-store-server-server-hstore-amd64
-        cache-to: type=gha,scope=pd-store-server-server-hstore-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Start compose stack with local images
@@ -290,6 +307,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
+      MODE: ${{ inputs.mode }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -297,15 +315,15 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_amd64="${IMAGE_REPO}:${VERSION_TAG}-amd64"
-        module_cache_scope="pd-store-server-${{ matrix.module }}-amd64"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
 
         {
           echo "image_amd64=$image_amd64"
-          echo "module_cache_scope=$module_cache_scope"
+          echo "module_cache_ref=$module_cache_ref"
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -331,8 +349,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.tags.outputs.image_amd64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
+        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build and push amd64 image (${{ matrix.module }})
@@ -344,8 +362,8 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: ${{ steps.tags.outputs.image_amd64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
+        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Smoke test standalone server amd64
@@ -386,6 +404,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
+      MODE: ${{ inputs.mode }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -393,15 +412,15 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_arm64="${IMAGE_REPO}:${VERSION_TAG}-arm64"
-        module_cache_scope="pd-store-server-${{ matrix.module }}-arm64"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
 
         {
           echo "image_arm64=$image_arm64"
-          echo "module_cache_scope=$module_cache_scope"
+          echo "module_cache_ref=$module_cache_ref"
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -429,8 +448,7 @@ jobs:
         platforms: linux/arm64
         push: true
         tags: ${{ steps.tags.outputs.image_arm64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
         build-args: ${{ env.MVN_ARGS }}
 
   publish_manifest:

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -26,7 +26,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
-            "registry_cache_image": "hugegraph/hubble:buildcache",
+            "registry_cache_image": "hugegraph/hubble:buildcache-latest",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -26,6 +26,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
+            "registry_cache_image": "hugegraph/hubble:buildcache",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -28,6 +28,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
+            "registry_cache_image": "hugegraph/hubble:buildcache",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -28,7 +28,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
-            "registry_cache_image": "hugegraph/hubble:buildcache",
+            "registry_cache_image": "hugegraph/hubble:buildcache-release",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false


### PR DESCRIPTION
## Summary

- add durable Docker Hub registry caches for Hubble, PD, Store, standalone Server, and HStore image builds
- isolate cache manifests by component and latest/release channel
- keep the existing GHA fallback for generic reusable image callers
- let PD/Store/HStore integration prechecks seed cold caches, let amd64 refresh caches, and let arm64 consume them without duplicate exports
- expose cache strategy and references in job summaries
- upgrade changed reusable workflows to actions/checkout@v7

## Why

Hubble caches had been evicted before the next real publish, while PD/Store/Server arm64 builds commonly spend 40–90 minutes running Maven under QEMU. Registry caches survive long gaps and allow the native BUILDPLATFORM build stage from apache/hugegraph#3092 to be reused by the arm64 runtime image jobs.

Companion Dockerfile change: apache/hugegraph#3092.
Hubble Dockerfile change: apache/hugegraph-toolchain#740.

## Cache topology

- Hubble: hugegraph/hubble:buildcache-latest and buildcache-release
- PD: hugegraph/pd:buildcache-latest and buildcache-release
- Store: hugegraph/store:buildcache-latest and buildcache-release
- HStore Server: hugegraph/server:buildcache-latest and buildcache-release
- Standalone Server: hugegraph/hugegraph:buildcache-latest and buildcache-release

## Verification

- actionlint passed for all changed workflows
- YAML, embedded matrix JSON, optional cache fallback, cache channel isolation, and reader/writer assertions passed
- official action versions were checked against current GitHub releases
- git diff --check passed
- independent cross-repository review and targeted re-review passed

The first publish creates cold registry caches. A subsequent publish should be used to measure hot-cache hit rate and arm64 duration. Real arm64 runtime health validation remains required for apache/hugegraph#3092.