### PR TITLE
feat(workflows): validate latest source branches

### DIFF
--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -141,6 +141,7 @@ jobs:
         IMAGE_REPO_RELEASE: ${{ matrix.image_repo_release }}
         PLATFORMS_LATEST: ${{ matrix.platforms_latest }}
         PLATFORMS_RELEASE: ${{ matrix.platforms_release }}
+        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image }}
       run: |
         set -euo pipefail
 
@@ -159,11 +160,35 @@ jobs:
         image_url="${image_repo}:${VERSION_TAG}"
         cache_scope="${COMPONENT}-${MODULE}"
 
+        if [ -n "$REGISTRY_CACHE_IMAGE" ]; then
+          cache_from="type=registry,ref=${REGISTRY_CACHE_IMAGE}"
+          cache_to_min="type=registry,ref=${REGISTRY_CACHE_IMAGE},mode=min"
+          cache_to_max="type=registry,ref=${REGISTRY_CACHE_IMAGE},mode=max"
+          cache_backend="registry"
+        else
+          cache_from="type=gha,scope=${cache_scope}"
+          cache_to_min="type=gha,scope=${cache_scope},mode=min"
+          cache_to_max="type=gha,scope=${cache_scope},mode=max"
+          cache_backend="gha"
+        fi
+
         {
           echo "image_url=$image_url"
           echo "platforms=$platforms"
           echo "cache_scope=$cache_scope"
+          echo "cache_from=$cache_from"
+          echo "cache_to_min=$cache_to_min"
+          echo "cache_to_max=$cache_to_max"
+          echo "cache_backend=$cache_backend"
         } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Build parameters: ${MODULE}"
+          echo
+          echo "| Image | Platforms | Cache backend | Cache reference |"
+          echo "| --- | --- | --- | --- |"
+          echo "| \`${image_url}\` | \`${platforms}\` | \`${cache_backend}\` | \`${REGISTRY_CACHE_IMAGE:-$cache_scope}\` |"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Checkout source (${{ matrix.module }})
       uses: actions/checkout@v6
@@ -196,8 +221,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=min
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_min }}
         build-args: ${{ inputs.mvn_args }}
 
     - name: Build x86 image for smoke test (${{ matrix.module }})
@@ -209,8 +234,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=min
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_min }}
 
     - name: Run smoke test (${{ matrix.module }})
       if: ${{ matrix.smoke_test }}
@@ -239,8 +264,8 @@ jobs:
         platforms: ${{ steps.params.outputs.platforms }}
         push: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=max
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_max }}
         build-args: ${{ inputs.mvn_args }}
 
     - name: Build and push image (${{ matrix.module }})
@@ -252,8 +277,8 @@ jobs:
         platforms: ${{ steps.params.outputs.platforms }}
         push: true
         tags: ${{ steps.params.outputs.image_url }}
-        cache-from: type=gha,scope=${{ steps.params.outputs.cache_scope }}
-        cache-to: type=gha,scope=${{ steps.params.outputs.cache_scope }},mode=max
+        cache-from: ${{ steps.params.outputs.cache_from }}
+        cache-to: ${{ steps.params.outputs.cache_to_max }}
 
   update_latest_hash:
     needs: [prepare, publish]

--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -141,7 +141,7 @@ jobs:
         IMAGE_REPO_RELEASE: ${{ matrix.image_repo_release }}
         PLATFORMS_LATEST: ${{ matrix.platforms_latest }}
         PLATFORMS_RELEASE: ${{ matrix.platforms_release }}
-        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image }}
+        REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image || '' }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -191,7 +191,7 @@ jobs:
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ inputs.repository_url }}
         ref: ${{ needs.prepare.outputs.checkout_ref }}

--- a/.github/workflows/_publish_image_reusable.yml
+++ b/.github/workflows/_publish_image_reusable.yml
@@ -19,6 +19,11 @@ on:
         description: "source branch name"
         required: true
         type: string
+      validation_only:
+        description: "build without image or cache writes"
+        required: false
+        default: false
+        type: boolean
       build_matrix_json:
         description: "build matrix JSON array"
         required: true
@@ -74,6 +79,7 @@ jobs:
       source_sha: ${{ steps.prepare.outputs.source_sha }}
       checkout_ref: ${{ steps.prepare.outputs.checkout_ref }}
       version_tag: ${{ steps.prepare.outputs.version_tag }}
+      publish_images: ${{ steps.prepare.outputs.publish_images }}
     steps:
     - name: Resolve mode and source ref
       id: prepare
@@ -82,6 +88,7 @@ jobs:
         REPOSITORY_URL: ${{ inputs.repository_url }}
         BRANCH: ${{ inputs.branch }}
         ENABLE_HASH_GATE: ${{ inputs.enable_hash_gate }}
+        VALIDATION_ONLY: ${{ inputs.validation_only }}
         LAST_HASH_VALUE: ${{ inputs.last_hash_value }}
       run: |
         set -euo pipefail
@@ -98,6 +105,10 @@ jobs:
         fi
 
         checkout_ref="$source_sha"
+        publish_images="true"
+        if [ "$VALIDATION_ONLY" = "true" ]; then
+          publish_images="false"
+        fi
 
         if [ "$MODE" = "latest" ]; then
           version_tag="latest"
@@ -118,6 +129,7 @@ jobs:
           echo "source_sha=$source_sha"
           echo "checkout_ref=$checkout_ref"
           echo "version_tag=$version_tag"
+          echo "publish_images=$publish_images"
           echo "need_update=$need_update"
         } >> "$GITHUB_OUTPUT"
 
@@ -142,6 +154,7 @@ jobs:
         PLATFORMS_LATEST: ${{ matrix.platforms_latest }}
         PLATFORMS_RELEASE: ${{ matrix.platforms_release }}
         REGISTRY_CACHE_IMAGE: ${{ matrix.registry_cache_image || '' }}
+        PUBLISH_IMAGES: ${{ needs.prepare.outputs.publish_images }}
       run: |
         set -euo pipefail
 
@@ -172,6 +185,11 @@ jobs:
           cache_backend="gha"
         fi
 
+        if [ "$PUBLISH_IMAGES" != "true" ]; then
+          cache_to_min=""
+          cache_to_max=""
+        fi
+
         {
           echo "image_url=$image_url"
           echo "platforms=$platforms"
@@ -188,6 +206,8 @@ jobs:
           echo "| Image | Platforms | Cache backend | Cache reference |"
           echo "| --- | --- | --- | --- |"
           echo "| \`${image_url}\` | \`${platforms}\` | \`${cache_backend}\` | \`${REGISTRY_CACHE_IMAGE:-$cache_scope}\` |"
+          echo
+          echo "- Publish images: \`${PUBLISH_IMAGES}\`"
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Checkout source (${{ matrix.module }})
@@ -262,7 +282,7 @@ jobs:
         context: ${{ matrix.context }}
         file: ${{ matrix.dockerfile }}
         platforms: ${{ steps.params.outputs.platforms }}
-        push: true
+        push: ${{ needs.prepare.outputs.publish_images == 'true' }}
         tags: ${{ steps.params.outputs.image_url }}
         cache-from: ${{ steps.params.outputs.cache_from }}
         cache-to: ${{ steps.params.outputs.cache_to_max }}
@@ -275,14 +295,14 @@ jobs:
         context: ${{ matrix.context }}
         file: ${{ matrix.dockerfile }}
         platforms: ${{ steps.params.outputs.platforms }}
-        push: true
+        push: ${{ needs.prepare.outputs.publish_images == 'true' }}
         tags: ${{ steps.params.outputs.image_url }}
         cache-from: ${{ steps.params.outputs.cache_from }}
         cache-to: ${{ steps.params.outputs.cache_to_max }}
 
   update_latest_hash:
     needs: [prepare, publish]
-    if: ${{ inputs.mode == 'latest' && inputs.enable_hash_gate && needs.prepare.outputs.need_update == 'true' && needs.publish.result == 'success' }}
+    if: ${{ inputs.mode == 'latest' && !inputs.validation_only && inputs.enable_hash_gate && needs.prepare.outputs.need_update == 'true' && needs.publish.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - name: Validate hash update inputs

--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -71,6 +71,8 @@ jobs:
       need_update: ${{ steps.prepare.outputs.need_update }}
       source_sha: ${{ steps.prepare.outputs.source_sha }}
       version_tag: ${{ steps.prepare.outputs.version_tag }}
+      cache_channel: ${{ steps.prepare.outputs.cache_channel }}
+      publish_images: ${{ steps.prepare.outputs.publish_images }}
       build_matrix_json: ${{ steps.prepare.outputs.build_matrix_json }}
     steps:
     - name: Resolve mode and source ref
@@ -96,7 +98,24 @@ jobs:
         fi
 
         if [ "$MODE" = "latest" ]; then
-          version_tag="latest"
+          if [ "$BRANCH" = "master" ]; then
+            version_tag="latest"
+            publish_images="true"
+          else
+            safe_branch="$(
+              printf '%s' "$BRANCH" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's/[^a-z0-9_.-]+/-/g; s/^[.-]+//; s/[.-]+$//' \
+              | cut -c1-110
+            )"
+            if [ -z "$safe_branch" ]; then
+              echo "Failed to derive an image tag from branch: $BRANCH"
+              exit 1
+            fi
+            version_tag="branch-${safe_branch}"
+            publish_images="false"
+          fi
+          cache_channel="latest"
           need_update="true"
           if [ "$ENABLE_HASH_GATE" = "true" ] && [ "$source_sha" = "$LAST_HASH_VALUE" ]; then
             need_update="false"
@@ -108,11 +127,15 @@ jobs:
             exit 1
           fi
           need_update="true"
+          cache_channel="release"
+          publish_images="true"
         fi
 
         {
           echo "source_sha=$source_sha"
           echo "version_tag=$version_tag"
+          echo "cache_channel=$cache_channel"
+          echo "publish_images=$publish_images"
           echo "need_update=$need_update"
           echo "build_matrix_json<<EOF"
           cat <<'JSON'
@@ -148,19 +171,20 @@ jobs:
 
     - name: Summarize build cache strategy
       env:
-        MODE: ${{ inputs.mode }}
+        CACHE_CHANNEL: ${{ steps.prepare.outputs.cache_channel }}
       run: |
         {
           echo "## PD / Store / Server image build"
           echo
           echo "- Cache backend: Docker Hub registry (BuildKit, mode=max)"
-          echo "- Cache channel: \`$MODE\`"
+          echo "- Cache channel: \`$CACHE_CHANNEL\`"
+          echo "- Publish images: \`${{ steps.prepare.outputs.publish_images }}\`"
           echo "- Cache writers: integration precheck and amd64 publish jobs"
           echo "- Cache reader: arm64 publish jobs"
-          echo "- PD: \`hugegraph/pd:buildcache-$MODE\`"
-          echo "- Store: \`hugegraph/store:buildcache-$MODE\`"
-          echo "- Server (HStore): \`hugegraph/server:buildcache-$MODE\`"
-          echo "- Server (standalone): \`hugegraph/hugegraph:buildcache-$MODE\`"
+          echo "- PD: \`hugegraph/pd:buildcache-$CACHE_CHANNEL\`"
+          echo "- Store: \`hugegraph/store:buildcache-$CACHE_CHANNEL\`"
+          echo "- Server (HStore): \`hugegraph/server:buildcache-$CACHE_CHANNEL\`"
+          echo "- Server (standalone): \`hugegraph/hugegraph:buildcache-$CACHE_CHANNEL\`"
         } >> "$GITHUB_STEP_SUMMARY"
 
   integration_precheck:
@@ -211,8 +235,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/pd:precheck
-        cache-from: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }}
-        cache-to: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }},mode=max
+        cache-from: type=registry,ref=hugegraph/pd:buildcache-${{ needs.prepare.outputs.cache_channel }}
+        cache-to: ${{ needs.prepare.outputs.publish_images == 'true' && format('type=registry,ref=hugegraph/pd:buildcache-{0},mode=max', needs.prepare.outputs.cache_channel) || '' }}
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Store image for integration check
@@ -223,8 +247,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/store:precheck
-        cache-from: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }}
-        cache-to: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }},mode=max
+        cache-from: type=registry,ref=hugegraph/store:buildcache-${{ needs.prepare.outputs.cache_channel }}
+        cache-to: ${{ needs.prepare.outputs.publish_images == 'true' && format('type=registry,ref=hugegraph/store:buildcache-{0},mode=max', needs.prepare.outputs.cache_channel) || '' }}
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Server(hstore) image for integration check
@@ -235,8 +259,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/server:precheck
-        cache-from: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }}
-        cache-to: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }},mode=max
+        cache-from: type=registry,ref=hugegraph/server:buildcache-${{ needs.prepare.outputs.cache_channel }}
+        cache-to: ${{ needs.prepare.outputs.publish_images == 'true' && format('type=registry,ref=hugegraph/server:buildcache-{0},mode=max', needs.prepare.outputs.cache_channel) || '' }}
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Start compose stack with local images
@@ -307,7 +331,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
-      MODE: ${{ inputs.mode }}
+      CACHE_CHANNEL: ${{ needs.prepare.outputs.cache_channel }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -315,7 +339,7 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_amd64="${IMAGE_REPO}:${VERSION_TAG}-amd64"
-        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${CACHE_CHANNEL}"
 
         {
           echo "image_amd64=$image_amd64"
@@ -350,7 +374,7 @@ jobs:
         load: true
         tags: ${{ steps.tags.outputs.image_amd64 }}
         cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
-        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
+        cache-to: ${{ needs.prepare.outputs.publish_images == 'true' && format('type=registry,ref={0},mode=max', steps.tags.outputs.module_cache_ref) || '' }}
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build and push amd64 image (${{ matrix.module }})
@@ -360,10 +384,10 @@ jobs:
         context: .
         file: ${{ matrix.dockerfile }}
         platforms: linux/amd64
-        push: true
+        push: ${{ needs.prepare.outputs.publish_images == 'true' }}
         tags: ${{ steps.tags.outputs.image_amd64 }}
         cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
-        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
+        cache-to: ${{ needs.prepare.outputs.publish_images == 'true' && format('type=registry,ref={0},mode=max', steps.tags.outputs.module_cache_ref) || '' }}
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Smoke test standalone server amd64
@@ -380,7 +404,7 @@ jobs:
         curl -fsS http://127.0.0.1:18080 >/dev/null || exit 1
 
     - name: Push tested amd64 image (${{ matrix.module }})
-      if: ${{ matrix.smoke_test }}
+      if: ${{ matrix.smoke_test && needs.prepare.outputs.publish_images == 'true' }}
       env:
         IMAGE_URL: ${{ steps.tags.outputs.image_amd64 }}
       run: |
@@ -404,7 +428,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
-      MODE: ${{ inputs.mode }}
+      CACHE_CHANNEL: ${{ needs.prepare.outputs.cache_channel }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -412,7 +436,7 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_arm64="${IMAGE_REPO}:${VERSION_TAG}-arm64"
-        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${CACHE_CHANNEL}"
 
         {
           echo "image_arm64=$image_arm64"
@@ -446,14 +470,14 @@ jobs:
         context: .
         file: ${{ matrix.dockerfile }}
         platforms: linux/arm64
-        push: true
+        push: ${{ needs.prepare.outputs.publish_images == 'true' }}
         tags: ${{ steps.tags.outputs.image_arm64 }}
         cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
         build-args: ${{ env.MVN_ARGS }}
 
   publish_manifest:
     needs: [prepare, publish_amd64, publish_arm64]
-    if: ${{ needs.prepare.outputs.need_update == 'true' && needs.publish_amd64.result == 'success' && needs.publish_arm64.result == 'success' }}
+    if: ${{ needs.prepare.outputs.need_update == 'true' && needs.prepare.outputs.publish_images == 'true' && needs.publish_amd64.result == 'success' && needs.publish_arm64.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -579,7 +603,7 @@ jobs:
 
   update_latest_hash:
     needs: [prepare, publish_manifest]
-    if: ${{ inputs.mode == 'latest' && inputs.enable_hash_gate && needs.prepare.outputs.need_update == 'true' && needs.publish_manifest.result == 'success' }}
+    if: ${{ inputs.mode == 'latest' && inputs.branch == 'master' && inputs.enable_hash_gate && needs.prepare.outputs.need_update == 'true' && needs.publish_manifest.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - name: Validate hash update inputs

--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -172,14 +172,19 @@ jobs:
     - name: Summarize build cache strategy
       env:
         CACHE_CHANNEL: ${{ steps.prepare.outputs.cache_channel }}
+        PUBLISH_IMAGES: ${{ steps.prepare.outputs.publish_images }}
       run: |
         {
           echo "## PD / Store / Server image build"
           echo
           echo "- Cache backend: Docker Hub registry (BuildKit, mode=max)"
           echo "- Cache channel: \`$CACHE_CHANNEL\`"
-          echo "- Publish images: \`${{ steps.prepare.outputs.publish_images }}\`"
-          echo "- Cache writers: integration precheck and amd64 publish jobs"
+          echo "- Publish images: \`$PUBLISH_IMAGES\`"
+          if [ "$PUBLISH_IMAGES" = "true" ]; then
+            echo "- Cache writers: integration precheck and amd64 publish jobs"
+          else
+            echo "- Cache policy: read-only validation (no registry exports)"
+          fi
           echo "- Cache reader: arm64 publish jobs"
           echo "- PD: \`hugegraph/pd:buildcache-$CACHE_CHANNEL\`"
           echo "- Store: \`hugegraph/store:buildcache-$CACHE_CHANNEL\`"

--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -146,6 +146,23 @@ jobs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
+    - name: Summarize build cache strategy
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        {
+          echo "## PD / Store / Server image build"
+          echo
+          echo "- Cache backend: Docker Hub registry (BuildKit, mode=max)"
+          echo "- Cache channel: \`$MODE\`"
+          echo "- Cache writers: integration precheck and amd64 publish jobs"
+          echo "- Cache reader: arm64 publish jobs"
+          echo "- PD: \`hugegraph/pd:buildcache-$MODE\`"
+          echo "- Store: \`hugegraph/store:buildcache-$MODE\`"
+          echo "- Server (HStore): \`hugegraph/server:buildcache-$MODE\`"
+          echo "- Server (standalone): \`hugegraph/hugegraph:buildcache-$MODE\`"
+        } >> "$GITHUB_STEP_SUMMARY"
+
   integration_precheck:
     needs: prepare
     if: ${{ needs.prepare.outputs.need_update == 'true' && inputs.strict_mode }}
@@ -164,7 +181,7 @@ jobs:
         fi
 
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -194,8 +211,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/pd:precheck
-        cache-from: type=gha,scope=pd-store-server-pd-amd64
-        cache-to: type=gha,scope=pd-store-server-pd-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/pd:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Store image for integration check
@@ -206,8 +223,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/store:precheck
-        cache-from: type=gha,scope=pd-store-server-store-amd64
-        cache-to: type=gha,scope=pd-store-server-store-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/store:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build x86 Server(hstore) image for integration check
@@ -218,8 +235,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: hg-ci/server:precheck
-        cache-from: type=gha,scope=pd-store-server-server-hstore-amd64
-        cache-to: type=gha,scope=pd-store-server-server-hstore-amd64,mode=min,ignore-error=true
+        cache-from: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }}
+        cache-to: type=registry,ref=hugegraph/server:buildcache-${{ inputs.mode }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Start compose stack with local images
@@ -290,6 +307,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
+      MODE: ${{ inputs.mode }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -297,15 +315,15 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_amd64="${IMAGE_REPO}:${VERSION_TAG}-amd64"
-        module_cache_scope="pd-store-server-${{ matrix.module }}-amd64"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
 
         {
           echo "image_amd64=$image_amd64"
-          echo "module_cache_scope=$module_cache_scope"
+          echo "module_cache_ref=$module_cache_ref"
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -331,8 +349,8 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ steps.tags.outputs.image_amd64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
+        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Build and push amd64 image (${{ matrix.module }})
@@ -344,8 +362,8 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: ${{ steps.tags.outputs.image_amd64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
+        cache-to: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }},mode=max
         build-args: ${{ env.MVN_ARGS }}
 
     - name: Smoke test standalone server amd64
@@ -386,6 +404,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
       VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
       MVN_ARGS: ${{ inputs.mvn_args }}
+      MODE: ${{ inputs.mode }}
     steps:
     - name: Resolve tags (${{ matrix.module }})
       id: tags
@@ -393,15 +412,15 @@ jobs:
         IMAGE_REPO: ${{ matrix.image_repo }}
       run: |
         image_arm64="${IMAGE_REPO}:${VERSION_TAG}-arm64"
-        module_cache_scope="pd-store-server-${{ matrix.module }}-arm64"
+        module_cache_ref="${IMAGE_REPO}:buildcache-${MODE}"
 
         {
           echo "image_arm64=$image_arm64"
-          echo "module_cache_scope=$module_cache_scope"
+          echo "module_cache_ref=$module_cache_ref"
         } >> "$GITHUB_OUTPUT"
 
     - name: Checkout source (${{ matrix.module }})
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ env.REPOSITORY_URL }}
         ref: ${{ env.SOURCE_SHA }}
@@ -429,8 +448,7 @@ jobs:
         platforms: linux/arm64
         push: true
         tags: ${{ steps.tags.outputs.image_arm64 }}
-        cache-from: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }}
-        cache-to: type=gha,scope=${{ steps.tags.outputs.module_cache_scope }},mode=min,ignore-error=true
+        cache-from: type=registry,ref=${{ steps.tags.outputs.module_cache_ref }}
         build-args: ${{ env.MVN_ARGS }}
 
   publish_manifest:

--- a/.github/workflows/publish_latest_ai_image.yml
+++ b/.github/workflows/publish_latest_ai_image.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
+    inputs:
+      latest_source_branch:
+        required: false
+        default: 'main'
+        description: 'source branch; non-main branches run read-only validation'
 
 jobs:
   publish:
@@ -12,7 +17,8 @@ jobs:
       mode: latest
       component: ai
       repository_url: apache/hugegraph-ai
-      branch: main
+      branch: ${{ github.event.inputs.latest_source_branch || 'main' }}
+      validation_only: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.latest_source_branch || 'main') != 'main' }}
       # IMPORTANT:
       # - Keep ARM enabled for normal RAG image (Dockerfile.llm).
       # - Keep rag-bin (Dockerfile.nk) on amd64 only due to arm incompatibility.
@@ -24,6 +30,7 @@ jobs:
             "dockerfile": "./docker/Dockerfile.llm",
             "image_repo_latest": "hugegraph/rag",
             "image_repo_release": "hugegraph/rag",
+            "registry_cache_image": "hugegraph/rag:buildcache-latest",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false
@@ -34,12 +41,13 @@ jobs:
             "dockerfile": "./docker/Dockerfile.nk",
             "image_repo_latest": "hugegraph/rag-bin",
             "image_repo_release": "hugegraph/rag-bin",
+            "registry_cache_image": "hugegraph/rag-bin:buildcache-latest",
             "platforms_latest": "linux/amd64",
             "platforms_release": "linux/amd64",
             "smoke_test": false
           }
         ]
-      enable_hash_gate: true
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'main') == 'main' }}
       last_hash_value: ${{ vars.LAST_AI_HASH }}
       last_hash_name: LAST_AI_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 23 * * *'
   workflow_dispatch:
     inputs:
+      latest_source_branch:
+        required: false
+        default: 'master'
+        description: 'source branch; non-master branches run read-only validation'
       mvn_args:
         required: false
         default: ''
@@ -17,7 +21,8 @@ jobs:
       mode: latest
       component: hubble
       repository_url: apache/hugegraph-toolchain
-      branch: master
+      branch: ${{ github.event.inputs.latest_source_branch || 'master' }}
+      validation_only: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.latest_source_branch || 'master') != 'master' }}
       build_matrix_json: |
         [
           {
@@ -34,7 +39,7 @@ jobs:
         ]
       use_mvn_args: true
       mvn_args: ${{ github.event.inputs.mvn_args || '' }}
-      enable_hash_gate: true
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'master') == 'master' }}
       last_hash_value: ${{ vars.LAST_HUBBLE_HASH }}
       last_hash_name: LAST_HUBBLE_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -26,7 +26,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
-            "registry_cache_image": "hugegraph/hubble:buildcache",
+            "registry_cache_image": "hugegraph/hubble:buildcache-latest",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_latest_hubble_image.yml
+++ b/.github/workflows/publish_latest_hubble_image.yml
@@ -26,6 +26,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
+            "registry_cache_image": "hugegraph/hubble:buildcache",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_latest_loader_image.yml
+++ b/.github/workflows/publish_latest_loader_image.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 23 * * *'
   workflow_dispatch:
     inputs:
+      latest_source_branch:
+        required: false
+        default: 'master'
+        description: 'source branch; non-master branches run read-only validation'
       mvn_args:
         required: false
         default: ''
@@ -17,7 +21,8 @@ jobs:
       mode: latest
       component: loader
       repository_url: apache/hugegraph-toolchain
-      branch: master
+      branch: ${{ github.event.inputs.latest_source_branch || 'master' }}
+      validation_only: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.latest_source_branch || 'master') != 'master' }}
       build_matrix_json: |
         [
           {
@@ -26,6 +31,7 @@ jobs:
             "dockerfile": "./hugegraph-loader/Dockerfile",
             "image_repo_latest": "hugegraph/loader",
             "image_repo_release": "hugegraph/loader",
+            "registry_cache_image": "hugegraph/loader:buildcache-latest",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false
@@ -33,7 +39,7 @@ jobs:
         ]
       use_mvn_args: true
       mvn_args: ${{ github.event.inputs.mvn_args || '' }}
-      enable_hash_gate: true
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'master') == 'master' }}
       last_hash_value: ${{ vars.LAST_LOADER_HASH }}
       last_hash_name: LAST_LOADER_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 23 * * *'
   workflow_dispatch:
     inputs:
+      latest_source_branch:
+        required: false
+        default: 'master'
+        description: 'apache/hugegraph branch to publish as the latest images'
       mvn_args:
         required: false
         default: ''
@@ -29,11 +33,11 @@ jobs:
     with:
       mode: latest
       repository_url: apache/hugegraph
-      branch: master
+      branch: ${{ github.event.inputs.latest_source_branch || 'master' }}
       mvn_args: ${{ github.event.inputs.mvn_args || '' }}
-      strict_mode: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.strict_mode == true || github.event.inputs.strict_mode == 'true' }}
+      strict_mode: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.latest_source_branch != 'master' || github.event.inputs.strict_mode == true || github.event.inputs.strict_mode == 'true' }}
       wait_timeout_sec: ${{ github.event.inputs.wait_timeout_sec || '300' }}
-      enable_hash_gate: true
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.latest_source_branch == 'master' }}
       last_hash_value: ${{ vars.LAST_SERVER_HASH }}
       last_hash_name: LAST_SERVER_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_latest_pd_store_server_image.yml
+++ b/.github/workflows/publish_latest_pd_store_server_image.yml
@@ -8,7 +8,7 @@ on:
       latest_source_branch:
         required: false
         default: 'master'
-        description: 'apache/hugegraph branch to publish as the latest images'
+        description: 'source branch; non-master branches run read-only validation'
       mvn_args:
         required: false
         default: ''
@@ -35,9 +35,9 @@ jobs:
       repository_url: apache/hugegraph
       branch: ${{ github.event.inputs.latest_source_branch || 'master' }}
       mvn_args: ${{ github.event.inputs.mvn_args || '' }}
-      strict_mode: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.latest_source_branch != 'master' || github.event.inputs.strict_mode == true || github.event.inputs.strict_mode == 'true' }}
+      strict_mode: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'master') != 'master' || github.event.inputs.strict_mode == true || github.event.inputs.strict_mode == 'true' }}
       wait_timeout_sec: ${{ github.event.inputs.wait_timeout_sec || '300' }}
-      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.latest_source_branch == 'master' }}
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'master') == 'master' }}
       last_hash_value: ${{ vars.LAST_SERVER_HASH }}
       last_hash_name: LAST_SERVER_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_latest_vermeer_image.yml
+++ b/.github/workflows/publish_latest_vermeer_image.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
+    inputs:
+      latest_source_branch:
+        required: false
+        default: 'master'
+        description: 'source branch; non-master branches run read-only validation'
 
 jobs:
   publish:
@@ -12,7 +17,8 @@ jobs:
       mode: latest
       component: vermeer
       repository_url: apache/hugegraph-computer
-      branch: master
+      branch: ${{ github.event.inputs.latest_source_branch || 'master' }}
+      validation_only: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.latest_source_branch || 'master') != 'master' }}
       build_matrix_json: |
         [
           {
@@ -21,12 +27,13 @@ jobs:
             "dockerfile": "./vermeer/Dockerfile",
             "image_repo_latest": "hugegraph/vermeer",
             "image_repo_release": "hugegraph/vermeer",
+            "registry_cache_image": "hugegraph/vermeer:buildcache-latest",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false
           }
         ]
-      enable_hash_gate: true
+      enable_hash_gate: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.latest_source_branch || 'master') == 'master' }}
       last_hash_value: ${{ vars.LAST_VERMEER_HASH }}
       last_hash_name: LAST_VERMEER_HASH
       hash_repo_owner: hugegraph

--- a/.github/workflows/publish_release_ai_image.yml
+++ b/.github/workflows/publish_release_ai_image.yml
@@ -27,6 +27,7 @@ jobs:
             "dockerfile": "./docker/Dockerfile.llm",
             "image_repo_latest": "hugegraph/rag",
             "image_repo_release": "hugegraph/rag",
+            "registry_cache_image": "hugegraph/rag:buildcache-release",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false
@@ -37,6 +38,7 @@ jobs:
             "dockerfile": "./docker/Dockerfile.nk",
             "image_repo_latest": "hugegraph/rag-bin",
             "image_repo_release": "hugegraph/rag-bin",
+            "registry_cache_image": "hugegraph/rag-bin:buildcache-release",
             "platforms_latest": "linux/amd64",
             "platforms_release": "linux/amd64",
             "smoke_test": false

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -28,6 +28,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
+            "registry_cache_image": "hugegraph/hubble:buildcache",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_release_hubble_image.yml
+++ b/.github/workflows/publish_release_hubble_image.yml
@@ -28,7 +28,7 @@ jobs:
             "dockerfile": "./hugegraph-hubble/Dockerfile",
             "image_repo_latest": "hugegraph/hubble",
             "image_repo_release": "hugegraph/hubble",
-            "registry_cache_image": "hugegraph/hubble:buildcache",
+            "registry_cache_image": "hugegraph/hubble:buildcache-release",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_release_loader_image.yml
+++ b/.github/workflows/publish_release_loader_image.yml
@@ -28,6 +28,7 @@ jobs:
             "dockerfile": "./hugegraph-loader/Dockerfile",
             "image_repo_latest": "hugegraph/loader",
             "image_repo_release": "hugegraph/loader",
+            "registry_cache_image": "hugegraph/loader:buildcache-release",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/.github/workflows/publish_release_vermeer_image.yml
+++ b/.github/workflows/publish_release_vermeer_image.yml
@@ -24,6 +24,7 @@ jobs:
             "dockerfile": "./vermeer/Dockerfile",
             "image_repo_latest": "hugegraph/vermeer",
             "image_repo_release": "hugegraph/vermeer",
+            "registry_cache_image": "hugegraph/vermeer:buildcache-release",
             "platforms_latest": "linux/amd64,linux/arm64",
             "platforms_release": "linux/amd64,linux/arm64",
             "smoke_test": false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,56 @@ The two publishing modes behave differently:
   - always publishes when invoked
   - derives the image tag from the release branch version
 
+## Multi-Platform Build Performance
+
+BuildKit exposes automatic platform arguments such as `BUILDPLATFORM` and
+`TARGETPLATFORM`. A multi-stage Dockerfile can pin an architecture-independent
+build stage to the native builder while leaving the runtime stage on the target
+platform:
+
+```dockerfile
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
+RUN mvn package ...
+
+FROM eclipse-temurin:11-jre-jammy
+COPY --from=build /pkg/dist/ /app/
+```
+
+Without the explicit build platform, every unqualified `FROM` defaults to the
+requested target platform. An amd64 GitHub runner therefore executes the entire
+arm64 Maven, Node, compression, or packaging workload through QEMU. Pinning the
+portable build stage prevents emulation while the final JRE/base image remains
+architecture correct.
+
+This is a BuildKit-only feature. Buildx requires Docker Engine 19.03 or newer,
+and the automatic platform arguments are documented in the Dockerfile frontend:
+
+- [Docker multi-platform build strategies](https://docs.docker.com/build/building/multi-platform/)
+- [Dockerfile automatic platform arguments](https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope)
+
+Use this optimization only when the copied build output is portable or is
+explicitly cross-compiled for `TARGETOS` / `TARGETARCH`. Native C/C++, CGO,
+JNI, platform-classifier artifacts, and downloaded executables must be audited
+and covered by real target-platform smoke tests. When the output is inherently
+target-specific, use a native target runner instead of forcing `BUILDPLATFORM`.
+
+Measured on the PD/Store/Server validation run from 2026-07-12, arm64 jobs fell
+from roughly 42-44 minutes to 6.2-6.8 minutes after moving the Java build stage
+off QEMU. Cache improvements are additional to this native-build optimization.
+
+### Read-Only Branch Validation
+
+Latest wrappers that expose `latest_source_branch` use two execution policies:
+
+- default branch (`master`, or `main` for AI): publish images, export registry
+  caches, create manifests, and update the corresponding `LAST_*_HASH` variable.
+- non-default branch: force validation checks, import existing caches read-only,
+  build all configured platforms, and skip image pushes, cache exports,
+  manifests, and hash updates.
+
+This allows an upstream Dockerfile branch to be benchmarked before merge without
+changing public images or production cache state.
+
 ## Critical Path: PD/Store/Server
 
 `pd/store/server` is the most important publishing flow in this repository and uses a dedicated reusable workflow:

--- a/README.md
+++ b/README.md
@@ -78,16 +78,10 @@ JNI, platform-classifier artifacts, and downloaded executables must be audited
 and covered by real target-platform smoke tests. When the output is inherently
 target-specific, use a native target runner instead of forcing `BUILDPLATFORM`.
 
-Measured on read-only validation runs from 2026-07-12:
-
-- PD/Store/Server arm64 jobs fell from roughly 42-44 minutes to 6.2-6.8
-  minutes.
-- Hubble's multi-platform job fell from 147.5 minutes to 8.8 minutes.
-- Loader's multi-platform run fell from roughly 30-40 minutes to 2.9 minutes.
-- Vermeer's multi-platform job fell from 13.3 minutes to 1.9 minutes.
-
-These results primarily come from moving portable build work off QEMU. Cache
-improvements are additional to the native-build or cross-compilation gains.
+The primary performance gain comes from moving portable build work off QEMU.
+Registry cache improvements are additional to the native-build or
+cross-compilation gains. Keep measured timings in pull requests or dated CI
+reports rather than this design document.
 
 ### Read-Only Branch Validation
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,16 @@ JNI, platform-classifier artifacts, and downloaded executables must be audited
 and covered by real target-platform smoke tests. When the output is inherently
 target-specific, use a native target runner instead of forcing `BUILDPLATFORM`.
 
-Measured on the PD/Store/Server validation run from 2026-07-12, arm64 jobs fell
-from roughly 42-44 minutes to 6.2-6.8 minutes after moving the Java build stage
-off QEMU. Cache improvements are additional to this native-build optimization.
+Measured on read-only validation runs from 2026-07-12:
+
+- PD/Store/Server arm64 jobs fell from roughly 42-44 minutes to 6.2-6.8
+  minutes.
+- Hubble's multi-platform job fell from 147.5 minutes to 8.8 minutes.
+- Loader's multi-platform run fell from roughly 30-40 minutes to 2.9 minutes.
+- Vermeer's multi-platform job fell from 13.3 minutes to 1.9 minutes.
+
+These results primarily come from moving portable build work off QEMU. Cache
+improvements are additional to the native-build or cross-compilation gains.
 
 ### Read-Only Branch Validation
 


### PR DESCRIPTION
## Summary

- allow every regular latest image workflow to validate an upstream source branch without writes
- add durable, channel-isolated registry caches for Hubble, Loader, Vermeer, RAG, RAG Bin, PD, Store, and Server
- run non-default branches with push=false, no cache exports, no manifests, and no hash updates
- document BUILDPLATFORM/TARGETPLATFORM, QEMU avoidance, native artifact boundaries, and measured results

## Measured validation

| Image flow | Before | After |
| --- | ---: | ---: |
| PD/Store/Server arm64 jobs | 42-44 min | 6.2-6.8 min |
| Hubble multi-platform | 147.5 min | 8.8 min |
| Loader multi-platform | 30-40 min | 2.9 min |
| Vermeer multi-platform | 13.3 min | 1.9 min |

Validation runs:
- Server: https://github.com/hugegraph/actions/actions/runs/29187175511
- Hubble: https://github.com/hugegraph/actions/actions/runs/29187794349
- Loader: https://github.com/hugegraph/actions/actions/runs/29188191489
- Vermeer: https://github.com/hugegraph/actions/actions/runs/29188192310

## Upstream changes

- apache/hugegraph#3092
- apache/hugegraph-toolchain#740
- apache/hugegraph-computer#353

## Safety

Default-branch and release builds retain image pushes, registry cache exports, manifests, and hash updates. Non-default validation imports caches read-only and never changes Docker Hub state.

AI RAG retains target-platform builds because its copied Python venv contains architecture-specific native wheels; only its cache and validation policy change.

## Verification

- actionlint passed for all changed workflows
- YAML and matrix JSON assertions passed
- all review comments addressed and resolved
- real read-only amd64/arm64 validations passed for Server, Hubble, Loader, and Vermeer
- git diff --check passed
- independent cross-repository reviews passed