### PR TITLE
fix(workflows): provide admin password in CI

### DIFF
--- a/.github/workflows/_publish_pd_store_server_reusable.yml
+++ b/.github/workflows/_publish_pd_store_server_reusable.yml
@@ -308,6 +308,11 @@ jobs:
     - name: Start compose stack with local images
       if: ${{ inputs.strict_mode }}
       run: |
+        HUGEGRAPH_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+        echo "::add-mask::$HUGEGRAPH_ADMIN_PASSWORD"
+        echo "HUGEGRAPH_ADMIN_PASSWORD=$HUGEGRAPH_ADMIN_PASSWORD" >> "$GITHUB_ENV"
+        export HUGEGRAPH_ADMIN_PASSWORD
+
         if [ -f "docker/docker-compose.dev.yml" ]; then
           compose_file="docker/docker-compose.dev.yml"
         elif [ -f "docker/docker-compose.yml" ]; then
@@ -526,6 +531,7 @@ jobs:
             --compressed \
             --connect-timeout 3 \
             --max-time 30 \
+            --user "admin:$HUGEGRAPH_ADMIN_PASSWORD" \
             -H 'Content-Type: application/json' \
             --data-binary "$payload" \
             http://127.0.0.1:8080/gremlin \


### PR DESCRIPTION
## Summary

- generate and mask an ephemeral HugeGraph administrator password for the Compose precheck
- persist it across Compose lifecycle steps
- authenticate Gremlin CRUD smoke-test requests with the generated credential

## Root cause

Upstream `apache/hugegraph` now requires `HUGEGRAPH_ADMIN_PASSWORD` when resolving its Compose files. The publishing workflow did not provide it, so Compose failed before starting any containers. Enabling the password also enables authentication, so the Gremlin HTTP smoke test must use the same credential.

## Verification

- `actionlint .github/workflows/_publish_pd_store_server_reusable.yml`
- `git diff --check`
- upstream `docker-compose.dev.yml` passes `docker compose config --quiet` with a generated password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 发布流程启动前自动生成随机管理员密码。
  * 管理员密码在自动化流程中经过脱敏处理，降低敏感信息泄露风险。
  * Gremlin 操作请求现使用生成的管理员凭据进行身份验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->